### PR TITLE
Change social/user/login $redirect from array to string

### DIFF
--- a/protected/modules/social/controllers/UserController.php
+++ b/protected/modules/social/controllers/UserController.php
@@ -56,8 +56,8 @@ class UserController extends \yupe\components\controllers\FrontController
                     $module = Yii::app()->getModule('user');
 
                     $redirect = (Yii::app()->getUser()->isSuperUser() && $module->loginAdminSuccess)
-                        ? [$module->loginAdminSuccess]
-                        : [$module->loginSuccess];
+                        ? $module->loginAdminSuccess
+                        : $module->loginSuccess;
 
                     Yii::app()->authenticationManager->setBadLoginCount(Yii::app()->getUser(), 0);
 


### PR DESCRIPTION
Just test the github oauth scene, or not yet complete.
$redirect is assigned as array, but [CWebUser::getReturnUrl](http://www.yiiframework.com/doc/api/1.1/CWebUser#getReturnUrl-detail) require a param string , so it return 'the application entry URL'  such as 'http://domain/social/login/service/github?code=XXX', then application call service authenticate() once again, as last error at GitHubOAuthService::getAccessToken -- "return $result['access_token']", and return 'Error 500! Undefined index: access_token'.